### PR TITLE
Send reply to browser and suppress output from mpv

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,13 +1,17 @@
 use serde::Deserialize;
 use std::io;
 use std::io::BufReader;
-use std::io::Read;
+use std::io::{Read, Write};
 
 use crate::error::FF2MpvError;
 
 #[derive(Deserialize)]
 pub struct FF2MpvMessage {
     pub url: String,
+}
+
+pub fn send_reply() -> Result<(), io::Error> {
+    send_message("ok")
 }
 
 pub fn get_mpv_message() -> Result<FF2MpvMessage, FF2MpvError> {
@@ -27,4 +31,14 @@ fn read_message() -> Result<String, io::Error> {
     let mut string = String::with_capacity(length as usize);
     reader.read_to_string(&mut string)?;
     Ok(string)
+}
+
+fn send_message(message: &str) -> Result<(), io::Error> {
+    let length = (message.len() as u32).to_ne_bytes();
+    let message = message.as_bytes();
+
+    let mut stdout = io::stdout();
+    stdout.write_all(&length)?;
+    stdout.write_all(message)?;
+    Ok(())
 }

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -11,7 +11,8 @@ pub struct FF2MpvMessage {
 }
 
 pub fn send_reply() -> Result<(), io::Error> {
-    send_message("ok")
+    // "ok" formatted as a JSON string
+    send_message("\"ok\"")
 }
 
 pub fn get_mpv_message() -> Result<FF2MpvMessage, FF2MpvError> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -64,12 +64,15 @@ impl Command {
         let config = Config::build();
         let ff2mpv_message = browser::get_mpv_message()?;
         Command::launch_mpv(config.player_command, config.player_args, &ff2mpv_message.url)?;
+        browser::send_reply()?;
         
         Ok(())
     }
 
     fn launch_mpv(command: String, args: Vec<String>, url: &str) -> Result<(), io::Error> {
         process::Command::new(command)
+            .stdout(process::Stdio::null())
+            .stderr(process::Stdio::null())
             .args(args)
             .arg(url)
             .spawn()?;


### PR DESCRIPTION
Sending the `"ok"` message (including the quotes for a JSON-formatted string) back to the browser prevents the `Error: An unexpected error occurred` lines in the browser console.

The output of mpv is suppressed so that it doesn't get read by the browser which then tries to parse it as JSON messages. Apart from also reducing log clutter, this change seems to have fixed a behavior where closing the browser also killed the mpv instance. This is only relevant when the `--no-terminal` option is unset. Maybe this option should be set by default, but I think the current way is fine as well where it's up to the user and you could technically even use a different player than mpv.