### PR TITLE
Make absolutely sure subprocess is not killed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ version = "1.1.4"
 dependencies = [
  "serde",
  "serde_json",
+ "windows",
 ]
 
 [[package]]
@@ -110,3 +111,120 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 serde = { version = "1.0.*", features = ["derive"] }
 serde_json = { version = "1.0.*", features = ["preserve_order"] }
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.56", features = ["Win32_System_Threading"] }
+
 [profile.dev-optimized]
 inherits = "dev"
 opt-level = 3

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,7 +1,8 @@
 use std::env;
 use std::io;
 use std::process;
-use serde_json::{self, json};
+
+use serde_json::json;
 
 use crate::browser;
 use crate::config::Config;
@@ -94,7 +95,7 @@ impl Command {
         // NOTE: On Windows, browser spawns process into a Job object.
         // NOTE: We need to detach player from the job, so it won't get killed after we're done,
         // NOTE: See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#closing_the_native_app
-        #[cfg(target_family = "windows")]
+        #[cfg(windows)]
         {
             use std::os::windows::process::CommandExt;
             const CREATE_BREAKAWAY_FROM_JOB: u32 = 0x01000000;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::path::PathBuf;
+
 use serde::Deserialize;
 
 use crate::error::FF2MpvError;
@@ -16,7 +17,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             player_command: "mpv".to_owned(),
-            player_args: vec![]
+            player_args: vec![],
         }
     }
 }
@@ -40,7 +41,7 @@ impl Config {
         Ok(config)
     }
 
-    #[cfg(target_family = "unix")]
+    #[cfg(unix)]
     fn get_config_location() -> PathBuf {
         let mut path = PathBuf::new();
 
@@ -57,7 +58,7 @@ impl Config {
         path
     }
 
-    #[cfg(target_family = "windows")]
+    #[cfg(windows)]
     fn get_config_location() -> PathBuf {
         let mut path = PathBuf::new();
         let appdata = env::var("APPDATA").unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
-use std::io;
 use std::fmt;
 use std::fmt::Display;
+use std::io;
 
 pub enum FF2MpvError {
     NoConfig,


### PR DESCRIPTION
- **cargo fmt**
- **Make absolutely sure subprocess is not killed**

I added code to set the process group. The docs mention it, even though it looks like it's not needed.

Also added a platform specific dependency to windows-rs, rather than hard-coding CREATE_BREAKAWAY_FROM_JOB.