### PR TITLE
feat: Support cookies via yt-dlp & integrate logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,44 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff2mpv-rust"
@@ -14,7 +48,40 @@ version = "1.1.7"
 dependencies = [
  "serde",
  "serde_json",
- "windows",
+ "tempfile",
+ "tracing",
+ "tracing-journald",
+ "tracing-layer-win-eventlog",
+ "tracing-subscriber",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -24,13 +91,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -40,10 +121,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -64,10 +206,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -114,6 +281,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,10 +307,189 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-journald"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-layer-win-eventlog"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa7d4b21dd1aba9d5784a6f8418092e021366603fc8d6390f3bda353fce24571"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "windows 0.61.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
 
 [[package]]
 name = "windows"
@@ -136,10 +497,19 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -148,7 +518,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -159,9 +542,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -170,9 +564,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -199,9 +593,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -209,8 +619,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -219,7 +638,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -228,7 +656,25 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -237,5 +683,93 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,18 @@ edition = "2024"
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.145", features = ["preserve_order"] }
+tracing = { version = "0.1", default-features = false }
+tempfile = "3"
+tracing-subscriber = { version = "0.3", features = [
+    "fmt",
+], default-features = false }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tracing-journald = { version = "0.3", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.2", features = ["Win32_System_Threading"] }
+tracing-layer-win-eventlog = { version = "1.0.0", default-features = false }
 
 [profile.release]
 strip = "symbols"
@@ -19,3 +28,7 @@ codegen-units = 1
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 missing-errors-doc = "allow"
+
+[features]
+default = []
+unstable_windows_logging = []

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 use crate::error::FF2MpvError;
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct FF2MpvMessage {
     pub url: String,
     pub options: Vec<String>,

--- a/src/command.rs
+++ b/src/command.rs
@@ -75,22 +75,23 @@ impl Command {
         let ff2mpv_message = browser::get_mpv_message()?;
         debug!("Parsed message: {ff2mpv_message:?}");
 
-        let mut extra_args: Vec<String> = Vec::new();
-        if let Some(cookie_file) = Command::export_cookies(
-            &config.ytdl_path,
-            &config.cookies_from_browser,
-            &ff2mpv_message.url,
-        ) && let Some(header) =
-            Command::build_cookie_argument(cookie_file.path(), &ff2mpv_message.url)
-        {
-            extra_args.push(format!(
+        let mut extra_args: Vec<String> = vec![
+            format!(
                 "--ytdl-raw-options-append=cookies-from-browser={}",
-                config.cookies_from_browser
-            ));
-            extra_args.push(format!(
-                "--script-opts=ytdl_hook-ytdl_path={}",
-                config.ytdl_path
-            ));
+                config.ytdl_cookies_from_browser
+            ),
+            format!("--script-opts=ytdl_hook-ytdl_path={}", config.ytdl_path),
+        ];
+
+        if config.force_inject_cookies.is_some_and(|v| v)
+            && let Some(cookie_file) = Command::export_cookies(
+                &config.ytdl_path,
+                &config.ytdl_cookies_from_browser,
+                &ff2mpv_message.url,
+            )
+            && let Some(header) =
+                Command::build_cookie_argument(cookie_file.path(), &ff2mpv_message.url)
+        {
             extra_args.push(format!("--http-header-fields-append=Cookie: {header}"));
         }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -76,12 +76,21 @@ impl Command {
         debug!("Parsed message: {ff2mpv_message:?}");
 
         let mut extra_args: Vec<String> = Vec::new();
-        if let Some(ref browser) = config.cookies_from_browser
-            && let Some(cookie_file) =
-                Command::export_cookies(&config.ytdl_path, browser, &ff2mpv_message.url)
-            && let Some(header) =
-                Command::build_cookie_argument(cookie_file.path(), &ff2mpv_message.url)
+        if let Some(cookie_file) = Command::export_cookies(
+            &config.ytdl_path,
+            &config.cookies_from_browser,
+            &ff2mpv_message.url,
+        ) && let Some(header) =
+            Command::build_cookie_argument(cookie_file.path(), &ff2mpv_message.url)
         {
+            extra_args.push(format!(
+                "--ytdl-raw-options-append=cookies-from-browser={}",
+                config.cookies_from_browser
+            ));
+            extra_args.push(format!(
+                "--script-opts=ytdl_hook-ytdl_path={}",
+                config.ytdl_path
+            ));
             extra_args.push(format!("--http-header-fields-append=Cookie: {header}"));
         }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,12 +1,10 @@
-use std::env;
-use std::io;
-use std::process;
+use std::{env, io, path::Path, process};
 
 use serde_json::json;
+use tempfile::NamedTempFile;
+use tracing::{debug, error, trace};
 
-use crate::browser;
-use crate::config::Config;
-use crate::error::FF2MpvError;
+use crate::{browser, config::Config, error::FF2MpvError};
 
 pub enum Command {
     ShowHelp,
@@ -18,13 +16,13 @@ pub enum Command {
 
 #[allow(clippy::unnecessary_wraps, reason = "More readable in show_help")]
 impl Command {
-    pub fn execute(&self) -> Result<(), FF2MpvError> {
+    pub fn execute(&self, config: &Config) -> Result<(), FF2MpvError> {
         match self {
             Command::ShowHelp => Self::show_help(),
             Command::ShowManifest => Self::show_manifest(false),
             Command::ShowManifestChromium => Self::show_manifest(true),
             Command::ValidateConfig => Self::validate_config(),
-            Command::FF2Mpv => Self::ff2mpv(),
+            Command::FF2Mpv => Self::ff2mpv(config),
         }
     }
 
@@ -73,14 +71,108 @@ impl Command {
         Ok(())
     }
 
-    fn ff2mpv() -> Result<(), FF2MpvError> {
-        let config = Config::build();
+    fn ff2mpv(config: &Config) -> Result<(), FF2MpvError> {
         let ff2mpv_message = browser::get_mpv_message()?;
-        let args = [config.player_args, ff2mpv_message.options].concat();
-        Command::launch_mpv(config.player_command, args, &ff2mpv_message.url)?;
+        debug!("Parsed message: {ff2mpv_message:?}");
+
+        let mut extra_args: Vec<String> = Vec::new();
+        if let Some(ref browser) = config.cookies_from_browser
+            && let Some(cookie_file) =
+                Command::export_cookies(&config.ytdl_path, browser, &ff2mpv_message.url)
+            && let Some(header) =
+                Command::build_cookie_argument(cookie_file.path(), &ff2mpv_message.url)
+        {
+            extra_args.push(format!("--http-header-fields-append=Cookie: {header}"));
+        }
+
+        let args = [
+            extra_args,
+            config.player_args.clone(),
+            ff2mpv_message.options,
+        ]
+        .concat();
+        if let Err(e) =
+            Command::launch_mpv(config.player_command.clone(), args, &ff2mpv_message.url)
+        {
+            debug!("Failed to launch mpv: {e}");
+            return Err(e.into());
+        }
+
         browser::send_reply()?;
+        trace!("Reply sent to browser");
 
         Ok(())
+    }
+
+    fn export_cookies(ytdl: &str, browser: &str, url: &str) -> Option<NamedTempFile> {
+        use std::io::Write;
+
+        let mut cookies = match NamedTempFile::new() {
+            Ok(f) => f,
+            Err(err) => {
+                debug!("Failed to create temporary file: {err:?}");
+                return None;
+            }
+        };
+
+        // yt-dlp expects a header to exist before writing
+        let _ = writeln!(cookies, "# Netscape HTTP Cookie File");
+        let cookie_filepath = cookies.path().to_string_lossy();
+
+        let output = process::Command::new(ytdl)
+            .args([
+                "--cookies-from-browser",
+                browser,
+                "--cookies",
+                cookie_filepath.as_ref(),
+                "--skip-download",
+                "--no-warnings",
+                url,
+            ])
+            .stdout(process::Stdio::null())
+            .output()
+            .expect("command to be valid");
+
+        if !output.stderr.is_empty() {
+            error!(
+                "yt-dlp command returned an error: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return None;
+        }
+
+        Some(cookies)
+    }
+
+    fn build_cookie_argument(cookie_file: &Path, url: &str) -> Option<String> {
+        let url_parts = url.split('/').collect::<Vec<&str>>();
+        let host = url_parts[2].split(':').next()?;
+
+        let content = std::fs::read_to_string(cookie_file).ok()?;
+        let cookies: Vec<String> = content
+            .lines()
+            .filter(|l| !l.starts_with('#') && !l.is_empty())
+            .filter_map(|line| {
+                let parts: Vec<&str> = line.splitn(7, '\t').collect();
+                if parts.len() < 7 {
+                    return None;
+                }
+                let domain = parts[0].trim_start_matches('.');
+                if domain == host {
+                    Some(format!("{}={}", parts[5], parts[6]))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if cookies.is_empty() {
+            debug!("no cookies found for host {host}");
+            None
+        } else {
+            debug!("Configured {} cookies for {host}", cookies.len());
+            Some(cookies.join("; "))
+        }
     }
 
     fn launch_mpv(command: String, args: Vec<String>, url: &str) -> Result<(), io::Error> {
@@ -93,6 +185,8 @@ impl Command {
 
         Command::detach_mpv(&mut command);
 
+        // WARN: Do not log `command` as it contains secrets
+        debug!("Launching mpv");
         command.spawn()?;
 
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ pub struct Config {
     pub player_command: String,
     pub player_args: Vec<String>,
     pub ytdl_path: String,
-    pub cookies_from_browser: Option<String>,
+    pub cookies_from_browser: String,
 }
 
 impl Default for Config {
@@ -24,7 +24,7 @@ impl Default for Config {
             player_command: "mpv".to_owned(),
             player_args: vec![String::from("--no-terminal"), String::from("--")],
             ytdl_path: "yt-dlp".to_string(),
-            cookies_from_browser: None,
+            cookies_from_browser: "firefox::none".to_string(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,18 +7,24 @@ use serde::Deserialize;
 
 use crate::error::FF2MpvError;
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct Config {
+    pub log_level: String,
     pub player_command: String,
     pub player_args: Vec<String>,
+    pub ytdl_path: String,
+    pub cookies_from_browser: Option<String>,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
+            log_level: "info".to_string(),
             player_command: "mpv".to_owned(),
             player_args: vec![String::from("--no-terminal"), String::from("--")],
+            ytdl_path: "yt-dlp".to_string(),
+            cookies_from_browser: None,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,16 @@ pub struct Config {
     pub player_command: String,
     pub player_args: Vec<String>,
     pub ytdl_path: String,
-    pub cookies_from_browser: String,
+    pub ytdl_cookies_from_browser: String,
+
+    /// Optional flag that when set will force cookies to be re-exported via yt-dlp for the given
+    /// browser ([`ytdl_cookies_from_browser`]) and pass them as input to the MPV command.
+    /// You probably don't need ths and shouldn't as it creates a temporary file[^1] that contains
+    /// cookies for the website you're trying to playback content on.
+    ///
+    /// [^1]: The temporary file is deleted as soon as this middle-man layer has completed executing
+    /// the mpv command. For more details around the temporary file, see <https://docs.rs/tempfile/3.27.0/tempfile/struct.NamedTempFile.html#security-1>
+    pub force_inject_cookies: Option<bool>,
 }
 
 impl Default for Config {
@@ -24,7 +33,8 @@ impl Default for Config {
             player_command: "mpv".to_owned(),
             player_args: vec![String::from("--no-terminal"), String::from("--")],
             ytdl_path: "yt-dlp".to_string(),
-            cookies_from_browser: "firefox::none".to_string(),
+            ytdl_cookies_from_browser: "firefox::none".to_string(),
+            force_inject_cookies: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,4 +99,9 @@ mod util {
             )
             .init();
     }
+
+    #[cfg(all(target_os = "windows", not(feature = "unstable_windows_logging")))]
+    pub(super) fn setup_logging(_log_level: &str) {
+        // No-op
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,22 @@
 use std::env;
 use std::process;
 
-use ff2mpv_rust::command::Command;
+use ff2mpv_rust::{command::Command, config::Config};
+use tracing::{debug, error};
 
 fn main() {
+    let config = Config::build();
+    util::setup_logging(&config.log_level);
+    debug!("Loaded config {config:?}");
+
     let mut args = env::args();
     args.next(); // Skip binary path
 
     let command_name = args.next().unwrap_or_default();
     let command = get_command(&command_name);
-    if let Err(e) = command.execute() {
-        eprintln!("{e}");
+
+    if let Err(e) = command.execute(&config) {
+        error!("Execution failed: {e}");
         process::exit(-1);
     }
 }
@@ -22,5 +28,75 @@ fn get_command(name: &str) -> Command {
         "manifest_chromium" => Command::ShowManifestChromium,
         "validate" => Command::ValidateConfig,
         _ => Command::FF2Mpv,
+    }
+}
+
+mod util {
+    use std::str::FromStr;
+
+    use tracing::level_filters::LevelFilter;
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    #[cfg(unix)]
+    const FALLBACK_LOGFILE_NAME: &str = "ff2mpv-rust.log";
+    #[cfg(unix)]
+    const FALLBACK_LOGFILE_LOC: &str = "~/.var/log/";
+
+    fn get_common_layers(log_level: &str) -> LevelFilter {
+        let level = if log_level.is_empty() {
+            "info"
+        } else {
+            log_level
+        };
+
+        LevelFilter::from_str(level).unwrap_or(LevelFilter::INFO)
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(super) fn setup_logging(log_level: &str) {
+        use std::fs;
+
+        let log_level_filter = self::get_common_layers(log_level);
+
+        match tracing_journald::layer() {
+            Ok(journald_layer) => tracing_subscriber::registry()
+                .with(log_level_filter)
+                .with(journald_layer)
+                .init(),
+            Err(err) => {
+                let fallback_file = format!("{FALLBACK_LOGFILE_LOC}{FALLBACK_LOGFILE_NAME}");
+                eprintln!("Failed to connect to journald {err:?}\nFalling back to {fallback_file}");
+
+                if fs::exists(FALLBACK_LOGFILE_LOC).is_err() {
+                    fs::create_dir_all(FALLBACK_LOGFILE_LOC)
+                        .expect("failed to create dir for log file");
+                }
+
+                tracing_subscriber::registry()
+                    .with(log_level_filter)
+                    .with(
+                        tracing_subscriber::fmt::layer()
+                            .with_ansi(false) // Disable colors
+                            .with_writer(
+                                fs::File::open(&fallback_file).expect("Failed to create log file"),
+                            ),
+                    )
+                    .init();
+            }
+        }
+    }
+
+    // TODO: Remove `unstable_windows_logging` feature flag once testing on windows is validated
+    #[cfg(all(target_os = "windows", feature = "unstable_windows_logging"))]
+    pub(super) fn setup_logging(log_level: &str) {
+        let log_level_filter = self::get_common_layers(log_level);
+
+        tracing_subscriber::registry()
+            .with(log_level_filter)
+            .with(
+                cfg!(target_os = "windows")
+                    .then(|| tracing_layer_win_eventlog::EventLogLayer::new("hello_world")),
+            )
+            .init();
     }
 }


### PR DESCRIPTION
The original goal of this commit was to add support for exporting
cookies via yt-dlp, but I also added tracing-logging & integrated it
with journald (at least for linux, the windows logging integration is
under a feature-flag and not tested as of this commit).

To support cookies, we look to see if the user has configured a profile
(in yt-dlp syntax) and then execute yt-dlp to export those cookies into
a temporary file (via the tempfile crate). Then, we read from that file
and create an mpv argument including all the headers, filtering it to
only the cookies for the host the user asked for.

Tested with local-network file, youtube, and twitch:
```
Apr 11 00:27:48 ClockTower ff2mpv-rust[356641]: Loaded config Config { log_level: "trace", player_command: "/usr/local/bin/mpv", player_args: ["--no-terminal", "--script-opts=ytdl_hook-ytdl_path=/home/kayo/.local/bin/yt-dlp", "--ytdl-raw-options-append=cookies-from-browser=firefox::none", "--"], ytdl_path: "/home/kayo/.local/bin/yt-dlp", cookies_from_browser: Some("firefox::none") }
Apr 11 00:27:48 ClockTower ff2mpv-rust[356641]: Parsed message: FF2MpvMessage { url: "http://10.0.0.138:8082/<snip>.mp4#t=15.964853", options: [] }
Apr 11 00:27:48 ClockTower ff2mpv-rust[356641]: Configured 12 cookies for 10.0.0.138
Apr 11 00:27:48 ClockTower ff2mpv-rust[356641]: Launching mpv
Apr 11 00:27:48 ClockTower ff2mpv-rust[356641]: Reply sent to browser

Apr 11 00:27:53 ClockTower ff2mpv-rust[356721]: Loaded config Config { log_level: "trace", player_command: "/usr/local/bin/mpv", player_args: ["--no-terminal", "--script-opts=ytdl_hook-ytdl_path=/home/kayo/.local/bin/yt-dlp", "--ytdl-raw-options-append=cookies-from-browser=firefox::none", "--"], ytdl_path: "/home/kayo/.local/bin/yt-dlp", cookies_from_browser: Some("firefox::none") }
Apr 11 00:27:53 ClockTower ff2mpv-rust[356721]: Parsed message: FF2MpvMessage { url: "https://www.youtube.com/watch?v=kt1HSEcVNp0", options: [] }
Apr 11 00:27:55 ClockTower ff2mpv-rust[356721]: Configured 2 cookies for www.youtube.com
Apr 11 00:27:55 ClockTower ff2mpv-rust[356721]: Launching mpv
Apr 11 00:27:55 ClockTower ff2mpv-rust[356721]: Reply sent to browser

Apr 11 00:28:22 ClockTower ff2mpv-rust[357046]: Loaded config Config { log_level: "trace", player_command: "/usr/local/bin/mpv", player_args: ["--no-terminal", "--script-opts=ytdl_hook-ytdl_path=/home/kayo/.local/bin/yt-dlp", "--ytdl-raw-options-append=cookies-from-browser=firefox::none", "--"], ytdl_path: "/home/kayo/.local/bin/yt-dlp", cookies_from_browser: Some("firefox::none") }
Apr 11 00:28:22 ClockTower ff2mpv-rust[357046]: Parsed message: FF2MpvMessage { url: "https://www.twitch.tv/alveussanctuary", options: [] }
Apr 11 00:28:23 ClockTower ff2mpv-rust[357046]: Configured 1 cookies for www.twitch.tv
Apr 11 00:28:23 ClockTower ff2mpv-rust[357046]: Launching mpv
Apr 11 00:28:23 ClockTower ff2mpv-rust[357046]: Reply sent to browser
```

My ff2mpv-rust config:
```json
# ~/.config/ff2mpv-rust.json
{
  "log_level": "trace",
  "player_command": "/usr/local/bin/mpv",
  "cookies_from_browser": "firefox::none",
  "ytdl_path": "/home/kayo/.local/bin/yt-dlp",
  "player_args": ["--no-terminal", "--"]
}
```

Firefox native hosts config:
```json
# ~/.mozilla/native-messaging-hosts/ff2mpv.json
{
  "name": "ff2mpv",
  "description": "ff2mpv's external manifest",
  "path": "/home/kayo/workspace/ff2mpv-rust/target/release/ff2mpv-rust",
  "type": "stdio",
  "allowed_extensions": [
    "ff2mpv@yossarian.net"
  ]
}
```

----

The added dependencies to increase the binary size, but it seems appropriate to me
```bash
# kayo @ ClockTower in ~/workspace/ff2mpv-rust on git:cookies x [11:28:55] 
$ cargo bloated
   Compiling ff2mpv-rust v1.1.7 (/home/kayo/workspace/ff2mpv-rust)
    Finished `release` profile [optimized] target(s) in 1.22s
   Analyzing binary "ff2mpv-rust": /home/kayo/workspace/ff2mpv-rust/target/release/ff2mpv-rust
   File   Size Section
100.0%  287KiB (file)
142.2%  408KiB (unstripped)
 58.4%  168KiB .text
 10.0% 28.6KiB .rodata
  8.5% 24.3KiB .eh_frame
  6.6% 18.9KiB .rela.dyn

  File  .text    Size  Crate
 65.9% 112.8%  189KiB  *
 13.7%  23.4% 39.2KiB  tracing_subscriber
 12.2%  20.9% 35.1KiB  ff2mpv_rust
 10.4%  17.8% 29.9KiB  serde_json
  4.8%   8.1% 13.6KiB  tracing_journald
  4.5%   7.8% 13.1KiB  ryu
  4.5%   7.7% 12.9KiB  tracing_core
  3.5%   6.0% 10.1KiB  std
  2.0%   3.4% 5.66KiB  memchr

  File    Size  .text  .rodata   (SHR) .data.rel.ro   (SHR) Crates                           Name
  4.4% 12.7KiB 2.26KiB 10.4KiB  200  B         0  B    0  B ryu                              ryu::pretty::format64
  4.1% 11.6KiB 9.68KiB  823  B 4.84KiB      1184  B    0  B ff2mpv_rust                      <ff2mpv_rust::command::Command>::execute
  3.4% 9.87KiB 9.70KiB  133  B 5.43KiB        32  B    0  B ff2mpv_rust                      <ff2mpv_rust::config::Config>::parse_config_file
  2.1% 5.89KiB 5.78KiB   50  B 4.85KiB        56  B    0  B ff2mpv_rust                      ff2mpv_rust::browser::get_mpv_message
  1.8% 5.04KiB 4.89KiB   29  B 5.39KiB       120  B  128  B tracing_subscriber,alloc,core,std,tracing_core <std::thread::local::LocalKey<core::cell::RefCell<alloc::string::String>>>::with::<<tracing_subscriber::fmt::fmt_layer::Layer<tracing_subscriber::layer::layered::Layered<tracing_core::metadata::LevelFilter, tracing_subscriber::registry::sharded::Registry>, tracing_subscriber::fmt::format::DefaultFields, tracing_subscriber::fmt::format::Format, std::fs::File> as tracing_subscriber::layer::Layer<tracing_subscriber::layer::layered::Layered<tracing_core::metadata::LevelFilter, tracing_subscriber::registry::sharded::Registry>>>::on_event::{closure#0}, ()>
  1.5% 4.25KiB 3.21KiB  185  B 5.44KiB       880  B   48  B ff2mpv_rust                      ff2mpv_rust::main
  1.2% 3.48KiB 3.25KiB   60  B 5.40KiB       176  B   56  B tracing_journald,tracing_core,tracing_subscriber <tracing_subscriber::layer::layered::Layered<tracing_journald::Layer, tracing_subscriber::layer::layered::Layered<tracing_core::metadata::LevelFilter, tracing_subscriber::registry::sharded::Registry>> as tracing_core::subscriber::Subscriber>::event
  1.0% 2.98KiB 2.72KiB  176  B 5.32KiB        88  B    0  B ff2mpv_rust                      <ff2mpv_rust::command::Command>::show_manifest
```

Note that I had to apply the following diff to use bloated
```bash
# kayo @ ClockTower in ~/workspace/ff2mpv-rust on git:cookies x [1:07:11] 
$ gd --patch -U1
diff --git a/Cargo.toml b/Cargo.toml
index df093c0..2a55a37 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,3 @@ strip = "symbols"
 lto = "fat"
-panic = "abort"
+# panic = "abort"
 codegen-units = 1
```